### PR TITLE
Add Docker configuration and initial instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.7.2
+ENV BUNDLE_PATH /bundle_cache
+RUN apt-get -qq update && apt-get -qq install -y postgresql-client
+RUN apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt -y install nodejs
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY Gemfile /usr/src/app/Gemfile
+COPY Gemfile.lock /usr/src/app/Gemfile.lock
+RUN npm install -g yarn
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
+EXPOSE 3000
+
+# Start the main process.
+# CMD ["bundle", "&&", "bundle", "exec", "rails", "s", "-b", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
-# README
+# Lister
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Installation
 
-Things you may want to cover:
+### Prerequisites
 
-* Ruby version
+If you're familiar with Docker, that and `docker-compose` are all you'll need.
 
-* System dependencies
+If not, you'll need a local PostgreSQL installation and Ruby 2.7.2 installed.
 
-* Configuration
+### Docker
 
-* Database creation
+Run `docker-compose up` to build the containers and bring up the environment.
+Then, in a separate terminal, use `docker-compose exec web bundle exec rails
+db:setup` to create and migrate the database.
 
-* Database initialization
+### Local
 
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+Ensure PostgreSQL is running. Then, run `bundle` to install all Ruby
+dependencies and `yarn` to install JS dependencies. After that, set up the
+database with `bundle exec rails db:setup`, then run the app with `bundle exec
+rails s`.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3"
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+  web:
+    build: .
+    command: ["bundle && yarn && bundle exec rails server -b 0.0.0.0"]
+    volumes:
+      - .:/usr/src/app
+      - bundle_cache:/bundle_cache
+    tmpfs: /usr/src/app/tmp
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    environment:
+      REDIS_URL: redis://redis
+      DATABASE_URL: postgres://postgres:password@db:5432
+  bundle_cache:
+    image: busybox
+    volumes:
+      - bundle_cache:/bundle_cache
+  redis:
+    image: redis
+volumes:
+  bundle_cache:


### PR DESCRIPTION
This PR adds initial install instructions and configuration for running in Docker. The Docker environment has a Redis instance just in case we can benefit from that (e.g. with HTTP caching).